### PR TITLE
TravisCI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: java
+jdk:
+  - oraclejdk7
+install: .travisci/script install
+before_script: .travisci/script before_script
+script: .travisci/script test
+after_script: .travisci/script after_script
+env:
+  - BUILDSTAGE=unittest
+  - BUILDSTAGE=integrationtest
+  - BUILDSTAGE=systemtest

--- a/.travisci/script
+++ b/.travisci/script
@@ -20,7 +20,7 @@ case $BUILDSTAGE in
       			mvn -f multilight/pom.xml test-compile
       			;;            
    	 		test )
-      			mvn clean failsafe:integration-test failsafe:verify -fae
+      			mvn -f multilight/pom.xml failsafe:integration-test failsafe:verify -fae
       			;;
       	esac
       	;;
@@ -53,3 +53,4 @@ case $BUILDSTAGE in
       	esac
 	  	;;
 esac
+exit $?

--- a/.travisci/script
+++ b/.travisci/script
@@ -9,7 +9,7 @@ case $BUILDSTAGE in
       			mvn -f multilight/pom.xml test-compile
       			;;            
       		test )
-      			mvn -f multilight/pom.xml test -fn
+      			mvn -f multilight/pom.xml test -fae
       			;;
    		esac
        	;;
@@ -20,7 +20,7 @@ case $BUILDSTAGE in
       			mvn -f multilight/pom.xml test-compile
       			;;            
    	 		test )
-      			mvn clean failsafe:integration-test failsafe:verify -fn
+      			mvn clean failsafe:integration-test failsafe:verify -fae
       			;;
       	esac
       	;;
@@ -37,7 +37,7 @@ case $BUILDSTAGE in
       			cd lightfish-st/target/dependency
       			unzip glassfish-3.1.2.2.zip
       			glassfish3/bin/asadmin start-domain
-      			glassfish3/bin/asadmin start-database
+      			glassfish3/bin/asadmin start-database --jvmoptions -Xmx128m
       			glassfish3/bin/asadmin deploy ../../../lightfish/target/lightfish.war 
       			;;
 

--- a/.travisci/script
+++ b/.travisci/script
@@ -1,0 +1,55 @@
+#!/usr/bin/env sh
+
+ACTION=$1
+
+case $BUILDSTAGE in
+    unittest )
+      	case $ACTION in
+      		install )
+      			mvn -f multilight/pom.xml test-compile
+      			;;            
+      		test )
+      			mvn -f multilight/pom.xml test -fn
+      			;;
+   		esac
+       	;;
+
+    integrationtest )
+      	case $ACTION in
+      		install )
+      			mvn -f multilight/pom.xml test-compile
+      			;;            
+   	 		test )
+      			mvn clean failsafe:integration-test failsafe:verify -fn
+      			;;
+      	esac
+      	;;
+
+    systemtest )
+	  	case $ACTION in
+	    	install ) 
+	        	mvn -f multilight/pom.xml -Djarsigner.skip clean install -DskipTests
+	        	mvn -f lightfish-st/pom.xml test-compile
+	        	;;
+
+	    	before_script )	
+            	mvn -f lightfish-st/pom.xml org.apache.maven.plugins:maven-dependency-plugin:2.7:copy -Dartifact=org.glassfish.main.distributions:glassfish:3.1.2.2:zip
+      			cd lightfish-st/target/dependency
+      			unzip glassfish-3.1.2.2.zip
+      			glassfish3/bin/asadmin start-domain
+      			glassfish3/bin/asadmin start-database
+      			glassfish3/bin/asadmin deploy ../../../lightfish/target/lightfish.war 
+      			;;
+
+      		test )
+            	mvn -f lightfish-st/pom.xml test
+            	;;
+
+        	after_script )
+				cd lightfish-st/target/dependency/glassfish3/bin
+				./asadmin stop-domain
+				./asadmin stop-database
+				;;
+      	esac
+	  	;;
+esac

--- a/.travisci/testtravis
+++ b/.travisci/testtravis
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+for stage in  unittest integrationtest systemtest
+do
+  export BUILDSTAGE=$stage
+  for action in install before_script test after_script
+  do
+    echo Running $stage / $action
+    .travisci/script $action
+  done
+done


### PR DESCRIPTION
These changes contain configuration for TravisCI service, allowing at least rudimentary public CI with three test stages. After enabling the GitHub hook, the (unit, integration, system) tests would be run at each commit. [Running example from my fork](https://travis-ci.org/pdudits/lightfish) shows failing integration and system tests, which corresponds to what I see on my local machine. 

`MonitoringAdminIT` fails because `MonitoringAdmin` gained much more dependencies in the meantime, I haven't looked for exact cause of the system test failure.